### PR TITLE
Fix a typo and reformat

### DIFF
--- a/adafruit_ili9341.py
+++ b/adafruit_ili9341.py
@@ -47,30 +47,31 @@ import displayio
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ILI9341.git"
 
-init_sequence = (b"\x01\x80\x80"# Software reset then delay 0x78 (120ms)
-                 b"\xEF\x03\x03\x80\x02"
-                 b"\xCF\x03\x00\xC1\x30"
-                 b"\xED\x04\x64\x03\x12\x81"
-                 b"\xE8\x03\x85\x00\x78"
-                 b"\xCB\x05\x39\x2C\x00\x34\x02"
-                 b"\xF7\x01\x20"
-                 b"\xEA\x02\x00\x00"
-                 b"\xc0\x01\x23"            # Power control VRH[5:0]
-                 b"\xc1\x01\x10"            # Power control SAP[2:0];BT[3:0]
-                 b"\xc5\x02\x3e\x28"        # VCM control
-                 b"\xc7\x01\x86"            # VCM control2
-                 b"\x36\x01\x38"            # Memory Access Control
-                 b"\x37\x01\x00"            # Vertical scroll zero
-                 b"\x3a\x01\x55"            # COLMOD: Pixel Format Set
-                 b"\xb1\x02\x00\x18"        # Frame Rate Control (In Normal Mode/Full Colors)
-                 b"\xb6\x03\x08\x82\x27"    # Display Function Control
-                 b"\xF2\x01\x00"            # 3Gamma Function Disable
-                 b"\x26\x01\x01"            # Gamma curve selected
-                 b"\xe0\x0f\x0F\x31\x2B\x0C\x0E\x08\x4E\xF1\x37\x07\x10\x03\x0E\x09\x00" # Set Gamma
-                 b"\xe1\x0f\x00\x0E\x14\x03\x11\x07\x31\xC1\x48\x08\x0F\x0C\x31\x36\x0F" # Set Gamma
-                 b"\x11\x80\x78"# Exit Sleep then delay 0x78 (120ms)
-                 b"\x29\x80\x78"# Display on then delay 0x78 (120ms)
-                 )
+_INIT_SEQUENCE = (
+    b"\x01\x80\x80"# Software reset then delay 0x78 (120ms)
+    b"\xEF\x03\x03\x80\x02"
+    b"\xCF\x03\x00\xC1\x30"
+    b"\xED\x04\x64\x03\x12\x81"
+    b"\xE8\x03\x85\x00\x78"
+    b"\xCB\x05\x39\x2C\x00\x34\x02"
+    b"\xF7\x01\x20"
+    b"\xEA\x02\x00\x00"
+    b"\xc0\x01\x23"            # Power control VRH[5:0]
+    b"\xc1\x01\x10"            # Power control SAP[2:0];BT[3:0]
+    b"\xc5\x02\x3e\x28"        # VCM control
+    b"\xc7\x01\x86"            # VCM control2
+    b"\x36\x01\x38"            # Memory Access Control
+    b"\x37\x01\x00"            # Vertical scroll zero
+    b"\x3a\x01\x55"            # COLMOD: Pixel Format Set
+    b"\xb1\x02\x00\x18"        # Frame Rate Control (In Normal Mode/Full Colors)
+    b"\xb6\x03\x08\x82\x27"    # Display Function Control
+    b"\xF2\x01\x00"            # 3Gamma Function Disable
+    b"\x26\x01\x01"            # Gamma curve selected
+    b"\xe0\x0f\x0F\x31\x2B\x0C\x0E\x08\x4E\xF1\x37\x07\x10\x03\x0E\x09\x00" # Set Gamma
+    b"\xe1\x0f\x00\x0E\x14\x03\x11\x07\x31\xC1\x48\x08\x0F\x0C\x31\x36\x0F" # Set Gamma
+    b"\x11\x80\x78"# Exit Sleep then delay 0x78 (120ms)
+    b"\x29\x80\x78"# Display on then delay 0x78 (120ms)
+)
 
 class ILI9341(displayio.Display):
     """ILI9341 display driver"""

--- a/adafruit_ili9341.py
+++ b/adafruit_ili9341.py
@@ -32,7 +32,8 @@ Implementation Notes
 
 **Hardware:**
 
-.. todo:: Add links to any specific hardware product page(s), or category page(s). Use unordered list & hyperlink rST
+.. todo:: Add links to any specific hardware product page(s), or category page(s).
+   Use unordered list & hyperlink rST
    inline format: "* `Link Text <url>`_"
 
 **Software and Dependencies:**
@@ -73,6 +74,7 @@ _INIT_SEQUENCE = (
     b"\x29\x80\x78"# Display on then delay 0x78 (120ms)
 )
 
+# pylint: disable=too-few-public-methods
 class ILI9341(displayio.Display):
     """ILI9341 display driver"""
     def __init__(self, bus):


### PR DESCRIPTION
This fixes a typo that prevents the library from working (and does a reformat). There's plenty more work to do on this library, but I've been able to use the TFT FeatherWing with a Feather M4 with this fix. Anyone please review, so we can point people to an in-progress working version.