### PR TITLE
Created an example that uses displayio

### DIFF
--- a/examples/ili9341_simpletest.py
+++ b/examples/ili9341_simpletest.py
@@ -8,11 +8,14 @@ import displayio
 import adafruit_ili9341
 
 spi = board.SPI()
+tft_cs = board.D9
+tft_dc = board.D10
+
 try:
-    display_bus = displayio.FourWire(spi, command=board.D10, chip_select=board.D9)
+    display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 except ValueError:
     displayio.release_displays()
-    display_bus = displayio.FourWire(spi, command=board.D10, chip_select=board.D9)
+    display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 
 display = adafruit_ili9341.ILI9341(display_bus)
 

--- a/examples/ili9341_simpletest.py
+++ b/examples/ili9341_simpletest.py
@@ -1,0 +1,38 @@
+"""
+This test will initialize the display using displayio
+and draw a solid red background
+"""
+
+import board
+import displayio
+import adafruit_ili9341
+
+spi = board.SPI()
+try:
+    display_bus = displayio.FourWire(spi, command=board.D10, chip_select=board.D9)
+except ValueError:
+    displayio.release_displays()
+    display_bus = displayio.FourWire(spi, command=board.D10, chip_select=board.D9)
+
+display = adafruit_ili9341.ILI9341(display_bus)
+
+# Make the display context
+splash = displayio.Group(max_size=10)
+display.show(splash)
+
+color_bitmap = displayio.Bitmap(320, 240, 1)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0xFF0000
+
+try:
+    bg_sprite = displayio.TileGrid(color_bitmap,
+                                   pixel_shader=color_palette,
+                                   position=(0, 0))
+except TypeError:
+    bg_sprite = displayio.TileGrid(color_bitmap,
+                                   pixel_shader=color_palette,
+                                   x=0, y=0)
+splash.append(bg_sprite)
+
+while True:
+    pass

--- a/examples/ili9341_simpletest.py
+++ b/examples/ili9341_simpletest.py
@@ -11,11 +11,8 @@ spi = board.SPI()
 tft_cs = board.D9
 tft_dc = board.D10
 
-try:
-    display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
-except ValueError:
-    displayio.release_displays()
-    display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
+displayio.release_displays()
+display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 
 display = adafruit_ili9341.ILI9341(display_bus)
 


### PR DESCRIPTION
Added a working simpletest example. Tested successfully with CircuitPython 4.0-beta4, the 2.4" TFT FeatherWing, and a Feather M4 Express. It _should_ also work with earlier versions of CP4, but that is untested.