### PR TITLE
Added example with pinout specific to the shield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+*.mpy
+.idea
 __pycache__
 _build
 *.pyc
 .env
 build*
 bundles
+*.DS_Store
+.eggs
+dist
+**/*.egg-info

--- a/examples/ili9341_shield_simpletest.py
+++ b/examples/ili9341_shield_simpletest.py
@@ -1,7 +1,7 @@
 """
 This test will initialize the display using displayio
-and draw a solid red background. The default pinouts are
-for the 2.4" TFT FeatherWing with a Feather M4 or M0.
+and draw a solid red background. Pinouts are for the 2.8"
+TFT Shield
 """
 
 import board
@@ -9,8 +9,8 @@ import displayio
 import adafruit_ili9341
 
 spi = board.SPI()
-tft_cs = board.D9
-tft_dc = board.D10
+tft_cs = board.D10
+tft_dc = board.D9
 
 displayio.release_displays()
 display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)


### PR DESCRIPTION
This adds an example with shield specific pins (D9 and D10 are swapped) so I can easily add it to my guide.