### PR TITLE
File changes to allow releasing on PyPI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,11 +22,11 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 # autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["displayio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
-    "displayio": ("https://adafruit-blinka-displayio.readthedocs.io/en/latest/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
-    "displayio": (
-        "https://adafruit-blinka-displayio.readthedocs.io/en/latest/",
-        "None",
-    ),
+    "displayio": ("https://adafruit-blinka-displayio.readthedocs.io/en/latest/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
+    "displayio": ("https://adafruit-blinka-displayio.readthedocs.io/en/latest/"),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,6 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 # autodoc_mock_imports = ["digitalio", "busio"]
-autodoc_mock_imports = ["displayio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
-    "displayio": ("https://adafruit-blinka-displayio.readthedocs.io/en/latest/"),
+    "displayio": ("https://adafruit-blinka-displayio.readthedocs.io/en/latest/", "None"),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,10 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
-    "displayio": ("https://adafruit-blinka-displayio.readthedocs.io/en/latest/", "None"),
+    "displayio": (
+        "https://adafruit-blinka-displayio.readthedocs.io/en/latest/",
+        "None",
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/examples/ili9341_shield_simpletest.py
+++ b/examples/ili9341_shield_simpletest.py
@@ -5,8 +5,8 @@ background, a smaller purple rectangle, and some yellow text.
 Pinouts are for the 2.8" TFT Shield
 """
 import board
-import displayio
 import terminalio
+import displayio
 from adafruit_display_text import label
 import adafruit_ili9341
 

--- a/examples/ili9341_simpletest.py
+++ b/examples/ili9341_simpletest.py
@@ -6,8 +6,8 @@ using native displayio modules.
 Pinouts are for the 2.4" TFT FeatherWing or Breakout with a Feather M4 or M0.
 """
 import board
-import displayio
 import terminalio
+import displayio
 from adafruit_display_text import label
 import adafruit_ili9341
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Adafruit-Blinka
-Adafruit_Blinka_Displayio
+adafruit-blinka-displayio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Adafruit-Blinka
-
+Adafruit_Blinka_Displayio

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=[
-        "Adafruit-Blinka",
-        "adafruit-blinka-displayio",
-    ],
+    install_requires=["Adafruit-Blinka", "adafruit-blinka-displayio",],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+"""A setuptools based setup module.
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+from setuptools import setup, find_packages
+
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="adafruit-circuitpython-ili9341",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    description="displayio driver for ILI9341 and ILI9340 TFT-LCD displays.",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    # The project's main homepage.
+    url="https://github.com/adafruit/Adafruit_CircuitPython_ili9341",
+    # Author details
+    author="Adafruit Industries",
+    author_email="circuitpython@adafruit.com",
+    install_requires=[
+        "Adafruit-Blinka",
+        "adafruit-blinka-displayio",
+    ],
+    # Choose your license
+    license="MIT",
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: System :: Hardware",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+    ],
+    # What does your project relate to?
+    keywords="adafruit blinka circuitpython micropython ili9341 display tft lcd displayio",
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    py_modules=["adafruit_ili9341"],
+)

--- a/setup.py.disabled
+++ b/setup.py.disabled
@@ -1,4 +1,0 @@
-"""
-This library is not deployed to PyPI. It is either a board-specific helper library, or
-does not make sense for use on or is incompatible with single board computers and Linux.
-"""


### PR DESCRIPTION
Now that I've been adding displayio, it makes sense to have this on PyPI. I made changes such as adding a setup.py file and setting displayio as a dependency to the drivers. After this is merged, I can test releasing. This will be the first driver to use it as a dependency so these changes will likely be needed in other displayio driver repos.