### PR TITLE
Type info

### DIFF
--- a/adafruit_ili9341.py
+++ b/adafruit_ili9341.py
@@ -85,7 +85,11 @@ _INIT_SEQUENCE = (
 
 # pylint: disable=too-few-public-methods
 class ILI9341(displayio.Display):
-    """ILI9341 display driver"""
+    """
+    ILI9341 display driver
+
+    :param displayio.FourWire bus: bus that the display is connected to
+    """
 
     def __init__(self, bus: displayio.FourWire, **kwargs: Any):
         super().__init__(bus, _INIT_SEQUENCE, **kwargs)

--- a/adafruit_ili9341.py
+++ b/adafruit_ili9341.py
@@ -46,6 +46,11 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 """
+try:
+    # used for typing only
+    from typing import Any
+except ImportError:
+    pass
 
 import displayio
 
@@ -82,5 +87,5 @@ _INIT_SEQUENCE = (
 class ILI9341(displayio.Display):
     """ILI9341 display driver"""
 
-    def __init__(self, bus, **kwargs):
+    def __init__(self, bus: displayio.FourWire, **kwargs: Any):
         super().__init__(bus, _INIT_SEQUENCE, **kwargs)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 # autodoc_mock_imports = ["digitalio", "busio"]
-autodoc_mock_imports = ["displayio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),


### PR DESCRIPTION
resolves #28

I am not certain whether using `Any` is the best option for `**kwargs` but there are many different possible types of the various different arguments that can get passed that way. I tried using some of the specific types but mypy still reported errors. I'm not sure if we have another option beyond breaking out all of the possible arguments and declaring types for all of them. I'm still pretty new to typing in python though, perhaps I've overlooked something or someone else has ideas.

There is possibly something that still needs done to make the sphinx docs correct. When building locally I'm not seeing the proper arguments for __init__(). But strangely when I build the docs from `main` I'm seeing the same issue. So perhaps there is some difference in my environment vs. in actions.

I tested this driver successfully with a Raspberry Pi B+ using Blinka_Displayio