### PR TITLE
docs: call displayio.release_displays() before SPI init in README example (fixes #39)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,14 @@ Usage Example
     import fourwire
     import adafruit_ili9341
 
+    # If you use explicit pins with busio.SPI(...), calling release_displays() first
+    # prevents "pin in use" errors on subsequent reloads.
+    displayio.release_displays()
+
     spi = board.SPI()
     tft_cs = board.D9
     tft_dc = board.D10
 
-    displayio.release_displays()
     display_bus = fourwire.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 
     display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
@@ -57,8 +60,8 @@ Usage Example
     color_palette[0] = 0xFF0000
 
     bg_sprite = displayio.TileGrid(color_bitmap,
-                                   pixel_shader=color_palette,
-                                   x=0, y=0)
+                                pixel_shader=color_palette,
+                                x=0, y=0)
     splash.append(bg_sprite)
 
     while True:


### PR DESCRIPTION
### What
Move `displayio.release_displays()` above SPI initialization in the README example and add a brief comment explaining why.

### Why
Initializing SPI before `displayio.release_displays()` can leave pins “in use” on subsequent reloads of `code.py`, especially when users switch to explicit `busio.SPI(...)` pins. This change prevents those errors. Fixes #39.

### Changes
- README.rst: call `displayio.release_displays()` before `spi = board.SPI()`
- Add comment:
  # If you use explicit pins with busio.SPI(...), calling release_displays() first
  # prevents "pin in use" errors on subsequent reloads.

### Scope
Docs-only; no runtime code changes.

### How to Verify
1) Flash the README example to a board with an ILI9341.
2) Save once → display initializes.
3) Modify and re-save (or reset) → no “pin in use” errors on reload.
